### PR TITLE
Fix the post command for latest anubis version

### DIFF
--- a/lib/obelisk/tasks/post.ex
+++ b/lib/obelisk/tasks/post.ex
@@ -16,15 +16,23 @@ defmodule Obelisk.Tasks.Post do
   @doc """
   Run the build task
   """
-  def run([]) do
+  def run({[], _options, _runtime_configuration}) do
     raise ArgumentError, message: "Cannot create a new post without the post name"
   end
 
   @doc """
   Run the build task
   """
-  def run(args) do
-    hd(args) |> Obelisk.Post.create
+  def run({[first_arg], _options, _runtime_configuration}) do
+    first_arg |> Obelisk.Post.create
   end
+
+  @doc """
+  Run the build task
+  """
+  def run({[_first_arg|_rest], _options, _runtime_configuration}) do
+    raise ArgumentError, message: "You should only provide one argument between \"\": your post name"
+  end
+
 
 end


### PR DESCRIPTION
Parameters to the `run` function coming from anubis (0.3.0) are now of the form `{arguments, options, runtime_configuration}` instead of only `arguments`.

TODO: fix other commands.